### PR TITLE
feat: add watcher pipeline to track files and tests

### DIFF
--- a/pipeline/watcher.py
+++ b/pipeline/watcher.py
@@ -1,0 +1,376 @@
+"""
+pipeline/watcher.py
+───────────────────
+Directory polling for batch and stream files.
+
+Two pollers run in separate threads:
+    BatchPoller  — watches from 6AM, processes 13 batch files once per day,
+                   then sleeps until 6AM tomorrow
+    StreamPoller — scans every 30 seconds continuously throughout the day
+
+FUTURE CHANGES NEEDED:
+    1. BatchPoller.processor.process() — currently calls TestProcessor (prints only)
+       Later: replace with real FileProcessor that validates + loads to DB
+    2. processed_today set — currently in-memory only, lost on restart
+       Later: replace with file_tracking table check
+    3. processed set — same as above
+       Later: replace with file_tracking table check
+    4. Alerter — currently missing, batch failure only logs a warning
+       Later: wire in AlertConfig from settings to send email on batch missing
+    5. _get_fallback_batch_dir — not implemented yet (IF NEEDED)
+       Later: implement fallback to yesterday's batch when today's never arrives
+
+CHECK:
+   LOGGING
+"""
+
+import os
+import time
+import logging
+import threading
+from datetime import date, datetime, timedelta
+
+logger = logging.getLogger(__name__)
+
+# ── Expected files ────────────────────────────────────────────
+
+BATCH_FILES = [
+    "customers.csv",
+    "drivers.csv",
+    "agents.csv",
+    "regions.csv",
+    "reasons.csv",
+    "categories.csv",
+    "segments.csv",
+    "teams.csv",
+    "channels.csv",
+    "priorities.csv",
+    "reason_categories.csv",
+    "restaurants.json",
+    "cities.json",
+]
+
+STREAM_FILES = [
+    "orders.json",
+    "tickets.csv",
+    "ticket_events.json",
+]
+
+# Batch window: only watch between these hours
+BATCH_WINDOW_START = 6   # 6AM  — before this, batch never arrives
+BATCH_WINDOW_END   = 14  # 2PM  — after all 13 done, sleep until next 6AM, but if past 2PM and still missing, keep watching + log warning
+
+
+# ── File stability check ──────────────────────────────────────
+
+def is_file_stable(filepath: str, wait_sec: int = 1) -> bool:
+    """
+    Check if a file is done being written.
+    Compare size before and after wait_sec seconds.
+    If size is the same the file is safe to read.
+
+    wait_sec: 1 for local files, 2-3 for network drives.
+    """
+    try:
+        size_before = os.path.getsize(filepath)
+        time.sleep(wait_sec)
+        size_after  = os.path.getsize(filepath)
+        return size_before == size_after
+    except OSError:
+        return False
+
+
+# ── Batch Poller ──────────────────────────────────────────────
+
+class BatchPoller:
+    """
+    Watches for today's 13 batch files.
+
+    Behaviour:
+    - Before 6AM: sleep until 6AM — batch never arrives this early
+    - 6AM onward: scan every poll_interval seconds until all 13 files found
+    - All 13 done: sleep until 6AM tomorrow — no point scanning again today
+    - If batch still missing after 2PM: keep watching + log warning
+    - Midnight: reset for the new day
+    """
+
+    def __init__(self, batch_base_dir: str, processor, poll_interval: int = 60):
+        self.batch_base_dir = batch_base_dir
+        self.processor      = processor
+        self.poll_interval  = poll_interval
+        self.running        = False
+        self._thread        = None
+
+        # FUTURE: add alerter parameter
+        # def __init__(self, batch_base_dir, processor, alerter, poll_interval=60):
+        #     self.alerter = alerter
+
+    def start(self):
+        self.running = True
+        self._thread = threading.Thread(
+            target=self._run,
+            name="BatchPoller",
+            daemon=True 
+        )
+        self._thread.start()
+        logger.info("BatchPoller started")
+        return self._thread
+
+    def stop(self):
+        self.running = False
+        logger.info("BatchPoller stopped")
+
+    def _run(self):
+
+        # CURRENT: in-memory set — lost every time pipeline restarts
+        # FUTURE:  remove this set entirely
+        #          replace every check (if filepath in processed_today)
+        #          with: file_tracker.get_status(filepath) == "success"
+        #          where file_tracker is a FileTracker instance from pipeline/file_tracker.py
+        processed_today = set()
+        current_day     = None
+        alert_sent      = False   # prevents sending duplicate alerts same day
+
+        while self.running:
+            today = date.today().isoformat()
+            now   = datetime.now()
+
+            # ── Midnight reset ─────────────────────────────────
+            if today != current_day:
+                logger.info(f"BatchPoller: new day {today}")
+                processed_today = set()   # FUTURE: no set to clear — file_tracking handles this
+                current_day     = today
+                alert_sent      = False
+
+            # ── Before 6AM: sleep until 6AM ───────────────────
+            if now.hour < BATCH_WINDOW_START:
+                wake_at   = datetime.combine(
+                                now.date(),
+                                datetime.min.time().replace(hour=BATCH_WINDOW_START)
+                            )
+                sleep_sec = (wake_at - now).total_seconds()
+                logger.info(
+                    f"BatchPoller: before batch window. "
+                    f"Sleeping {sleep_sec/60:.0f} min until 6AM."
+                )
+                time.sleep(sleep_sec)
+                continue
+
+            # ── Batch folder not here yet ──────────────────────
+            batch_dir = os.path.join(self.batch_base_dir, today)
+
+            if not os.path.exists(batch_dir):
+                logger.debug(f"BatchPoller: waiting for {batch_dir}")
+                time.sleep(self.poll_interval)
+                continue
+
+            # ── Scan all 13 expected files ─────────────────────
+            for filename in BATCH_FILES:
+                filepath = os.path.join(batch_dir, filename)
+
+                # CURRENT: check in-memory set
+                # FUTURE:  status = file_tracker.get_status(filepath)
+                #          if status == "success": continue
+                #          if status == "in_progress": pass  ← reprocess crashed file
+                #          if status is None: pass           ← new file, process it
+                if filepath in processed_today:
+                    continue
+
+                if not os.path.exists(filepath):
+                    continue
+
+                if not is_file_stable(filepath):
+                    logger.debug(f"BatchPoller: file still writing: {filepath}")
+                    continue
+
+                logger.info(f"BatchPoller: found → {filepath}")
+
+                # CURRENT: calls TestProcessor which only prints
+                # FUTURE:  calls real FileProcessor which:
+                #          1. marks file as in_progress in file_tracking
+                #          2. reads and parses file
+                #          3. validates schema and business rules
+                #          4. checks orphans
+                #          5. loads to warehouse
+                #          6. marks file as success in file_tracking
+                self.processor.process(filepath, file_type="batch")
+
+                # CURRENT: add to in-memory set
+                # FUTURE:  remove this line — file_tracking table handles dedup
+                processed_today.add(filepath)
+
+            # ── Check if ALL 13 files are done ─────────────────
+            all_done = all(
+                os.path.join(batch_dir, f) in processed_today
+                for f in BATCH_FILES
+                # FUTURE: replace with:
+                # file_tracker.get_status(os.path.join(batch_dir, f)) == "success"
+            )
+
+            if all_done:
+                tomorrow_6am = datetime.combine(
+                    now.date() + timedelta(days=1),
+                    datetime.min.time().replace(hour=BATCH_WINDOW_START)
+                )
+                sleep_sec = (tomorrow_6am - now).total_seconds()
+                logger.info(
+                    f"BatchPoller: all {len(BATCH_FILES)} files processed. "
+                    f"Sleeping {sleep_sec/3600:.1f}h until 6AM tomorrow."
+                )
+                time.sleep(sleep_sec)
+
+            else:
+                missing = [
+                    f for f in BATCH_FILES
+                    if os.path.join(batch_dir, f) not in processed_today
+                    # FUTURE: replace condition with file_tracking check
+                ]
+
+                # ── Past 2PM and still missing — alert once ────
+                if now.hour >= BATCH_WINDOW_END and not alert_sent:
+                    logger.critical(
+                        f"BatchPoller: CRITICAL — past {BATCH_WINDOW_END}:00, "
+                        f"batch still incomplete. Missing: {missing}"
+                    )
+
+                    # FUTURE: send real alert
+                    # self.alerter.send_async(
+                    #     subject="CRITICAL: Batch files missing",
+                    #     body=f"Date: {today}\nMissing: {missing}"
+                    # )
+
+                    # FUTURE: load fallback from yesterday's batch
+                    # fallback_dir = self._get_fallback_batch_dir(today)
+                    # if fallback_dir:
+                    #     self._load_fallback(fallback_dir)
+                    # else:
+                    #     logger.critical("No fallback batch available")
+
+                    alert_sent = True
+
+                else:
+                    logger.debug(
+                        f"BatchPoller: {len(processed_today)}/{len(BATCH_FILES)} done. "
+                        f"Still waiting for: {missing}"
+                    )
+
+                time.sleep(self.poll_interval)
+
+    # FUTURE: implement this method
+    # def _get_fallback_batch_dir(self, today: str) -> str | None:
+    #     """Find most recent previous complete batch as fallback."""
+    #     for days_back in range(1, 8):
+    #         past_date = (
+    #             datetime.strptime(today, "%Y-%m-%d") - timedelta(days=days_back)
+    #         ).strftime("%Y-%m-%d")
+    #         past_dir  = os.path.join(self.batch_base_dir, past_date)
+    #         past_done = all(
+    #             os.path.exists(os.path.join(past_dir, f))
+    #             for f in BATCH_FILES
+    #         )
+    #         if past_done:
+    #             logger.warning(f"BatchPoller: fallback found at {past_dir}")
+    #             return past_dir
+    #     return None
+
+
+# ── Stream Poller ─────────────────────────────────────────────
+
+class StreamPoller:
+    """
+    Scans all HH/ subfolders under today's stream directory.
+    Runs every 30 seconds continuously.
+    Calls processor.process() for each new file found.
+    Each file is reported exactly once per session.
+
+    Within-session dedup:  handled by processed set (current)
+    Cross-restart dedup:   handled by file_tracking table (future)
+    """
+
+    def __init__(self, stream_base_dir: str, processor, poll_interval: int = 30):
+        self.stream_base_dir = stream_base_dir
+        self.processor       = processor
+        self.poll_interval   = poll_interval
+        self.running         = False
+        self._thread         = None
+
+    def start(self):
+        self.running = True
+        self._thread = threading.Thread(
+            target=self._run,
+            name="StreamPoller",
+            daemon=True
+        )
+        self._thread.start()
+        logger.info("StreamPoller started")
+        return self._thread
+
+    def stop(self):
+        self.running = False
+        logger.info("StreamPoller stopped")
+
+    def _run(self):
+
+        # CURRENT: in-memory set — works within one session only
+        # FUTURE:  remove this set entirely
+        #          replace (if filepath in processed) check
+        #          with: file_tracker.get_status(filepath) == "success"
+        processed = set()
+
+        while self.running:
+            today      = date.today().isoformat()
+            stream_dir = os.path.join(self.stream_base_dir, today)
+
+            if not os.path.exists(stream_dir):
+                logger.debug(f"StreamPoller: no stream dir yet for {today}")
+                time.sleep(self.poll_interval)
+                continue
+
+            # Scan all HH/ subfolders sorted oldest → newest
+            hour_folders = sorted([
+                f for f in os.listdir(stream_dir)
+                if os.path.isdir(os.path.join(stream_dir, f))
+            ])
+
+            for hour_folder in hour_folders:
+                hour_path = os.path.join(stream_dir, hour_folder)
+
+                for filename in STREAM_FILES:
+                    filepath = os.path.join(hour_path, filename)
+
+                    if not os.path.exists(filepath):
+                        continue
+
+                    # CURRENT: check in-memory set
+                    # FUTURE:  status = file_tracker.get_status(filepath)
+                    #          if status == "success":     continue
+                    #          if status == "in_progress": pass  ← crashed, reprocess
+                    #          if status is None:          pass  ← new file
+                    if filepath in processed:
+                        continue
+
+                    if not is_file_stable(filepath):
+                        logger.debug(f"StreamPoller: file still writing: {filepath}")
+                        continue
+
+                    logger.info(f"StreamPoller: found → {filepath}")
+
+                    # CURRENT: calls TestProcessor which only prints
+                    # FUTURE:  calls real FileProcessor which:
+                    #          1. marks in_progress in file_tracking
+                    #          2. reads file (pandas / json.load)
+                    #          3. validates schema + business rules
+                    #          4. deduplicates on ID column
+                    #          5. checks nulls → quarantine
+                    #          6. checks orphans → orphan_staging
+                    #          7. loads valid records to warehouse
+                    #          8. calculates SLA fields (fact_tickets)
+                    #          9. logs quality metrics
+                    #          10. marks success in file_tracking
+                    self.processor.process(filepath, file_type="stream")
+
+                    # CURRENT: add to in-memory set
+                    # FUTURE:  remove — file_tracking handles this permanently
+                    processed.add(filepath)
+
+            time.sleep(self.poll_interval)

--- a/test_watcher.py
+++ b/test_watcher.py
@@ -1,0 +1,139 @@
+"""
+tests/test_watcher.py
+─────────────────────
+Live watcher test — runs until Ctrl+C.
+
+How to use:
+    Terminal 1: python tests/test_watcher.py
+    Terminal 2: python scripts/generate_stream_data.py --date 2026-03-17 --hour 10
+"""
+
+import os
+import sys
+import signal
+import logging
+import pipeline.watcher as watcher_module
+
+from datetime import datetime
+from pipeline.watcher import BatchPoller, StreamPoller
+
+# ── Constants ─────────────────────────────────────────────────
+BATCH_DIR  = "scripts/data/input/batch"
+STREAM_DIR = "scripts/data/input/stream"
+
+BATCH_POLL_INTERVAL  = 10   # seconds — 60 in production
+STREAM_POLL_INTERVAL = 5    # seconds — 30 in production
+
+# ── Override batch window so test works at any hour of day ────
+watcher_module.BATCH_WINDOW_START = datetime.now().hour
+watcher_module.BATCH_WINDOW_END   = datetime.now().hour + 8
+
+# ── Logging ───────────────────────────────────────────────────
+logging.basicConfig(
+    level  = logging.INFO,
+    format = "%(asctime)s | %(threadName)-12s | %(message)s",
+    datefmt= "%H:%M:%S"
+)
+
+
+# ── Processor ─────────────────────────────────────────────────
+class TestProcessor:
+    """
+    Receives detected files from both pollers.
+    Prints each file and keeps a running count.
+    In production this would be replaced by the real FileProcessor.
+    """
+
+    def __init__(self):
+        self.batch_count  = 0
+        self.stream_count = 0
+
+    def process(self, filepath: str, file_type: str) -> None:
+        filename    = os.path.basename(filepath)
+        parent_dir  = os.path.basename(os.path.dirname(filepath))
+
+        if file_type == "batch":
+            self.batch_count += 1
+            print(f"\n  [BATCH  {self.batch_count:02d}] {parent_dir}/{filename}")
+
+        elif file_type == "stream":
+            self.stream_count += 1
+            print(f"\n  [STREAM {self.stream_count:02d}] {parent_dir}/{filename}")
+
+
+# ── Shutdown ──────────────────────────────────────────────────
+def build_shutdown_handler(batch_poller, stream_poller, processor):
+    """
+    Returns a shutdown function that stops both pollers
+    and prints a summary before exiting.
+    Registered as Ctrl+C handler before join() is called.
+    """
+    def shutdown(sig, frame):
+        print("\n\n" + "=" * 55)
+        print("  Stopping watchers...")
+        batch_poller.stop()
+        stream_poller.stop()
+        print(f"  Batch files detected:  {processor.batch_count}")
+        print(f"  Stream files detected: {processor.stream_count}")
+        print("=" * 55)
+        sys.exit(0)
+
+    return shutdown
+
+
+# ── Banner ────────────────────────────────────────────────────
+def print_banner():
+    print("=" * 55)
+    print("  FastFeast — Live Watcher Test")
+    print("=" * 55)
+    print(f"  Batch dir:    {BATCH_DIR}")
+    print(f"  Stream dir:   {STREAM_DIR}")
+    print(f"  Batch window: {watcher_module.BATCH_WINDOW_START}:00 — {watcher_module.BATCH_WINDOW_END}:00")
+    print(f"  Batch poll:   every {BATCH_POLL_INTERVAL}s  (production: 60s)")
+    print(f"  Stream poll:  every {STREAM_POLL_INTERVAL}s  (production: 30s)")
+    print()
+    print("  Send files from Terminal 2:")
+    print("  cd scripts")
+    print("  python generate_stream_data.py --date 2026-03-17 --hour 10")
+    print()
+    print("  Press Ctrl+C to stop")
+    print("=" * 55)
+
+
+# ── Main ──────────────────────────────────────────────────────
+def main():
+
+    processor = TestProcessor()
+
+    batch_poller = BatchPoller(
+        batch_base_dir = BATCH_DIR,
+        processor      = processor,
+        poll_interval  = BATCH_POLL_INTERVAL
+    )
+
+    stream_poller = StreamPoller(
+        stream_base_dir = STREAM_DIR,
+        processor       = processor,
+        poll_interval   = STREAM_POLL_INTERVAL
+    )
+
+    # Register shutdown 
+    shutdown = build_shutdown_handler(batch_poller, stream_poller, processor)
+    signal.signal(signal.SIGINT, shutdown)
+
+    print_banner()
+
+    batch_thread  = batch_poller.start()
+    stream_thread = stream_poller.start()
+
+    # Keep main thread alive — join(timeout=1) lets Ctrl+C fire on Windows
+    try:
+        while True:
+            batch_thread.join(timeout=1)
+            stream_thread.join(timeout=1)
+    except KeyboardInterrupt:
+        shutdown(None, None)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
###  Overview
Two components added:
- `pipeline/watcher.py` — the file watcher that monitors input directories
- `test_watcher.py` — a live two-terminal test that simulates real production behavior

---

### `pipeline/watcher.py`

The watcher monitors two input directories for incoming files and hands each file to a processor the moment it is safe to read.

#### `is_file_stable(filepath)`
Before any file is processed, this checks the file is fully written by comparing size before and after a 1-second wait. If size is unchanged, the file is safe to read. This prevents reading a file that FastFeast is still writing.

#### `BatchPoller`
Watches `data/input/batch/YYYY-MM-DD/` for the **13 daily dimension files**.  
Runs in its own background thread.

| Time | Behaviour |
|------|-----------|
| Before 6AM | Sleeps until 6AM — batch never arrives earlier |
| 6AM → 2PM | Scans every `poll_interval` seconds until all 13 files found |
| All 13 done | Sleeps until 6AM tomorrow |
| Past 2PM, files missing | Logs `CRITICAL` once and keeps watching |
| Midnight | Resets automatically for the new day |

Each file is processed **exactly once** per day using an in-memory `processed_today` set.  
>  **Future:** replace with `file_tracking` DB table so restarts don't reprocess files.

#### `StreamPoller`
Watches `data/input/stream/YYYY-MM-DD/HH/` for the **3 micro-batch files**.  
Runs continuously in its own background thread, scanning every `poll_interval` seconds.

- Scans hour folders **oldest → newest** for correct ordering on recovery after unexpected restart
- Each file is processed **exactly once** per session using an in-memory `processed` set
- >  **Future:** same `file_tracking` replacement as BatchPoller

Both pollers call `processor.process(filepath, file_type)` — they never care what the processor does internally. This means **watcher.py never needs to change** when real processing logic is added later.

---

###  `test_watcher.py`
Live two-terminal test — watcher starts first with no data, files land while it is already running.

- **`TestProcessor`** — fake processor that prints each detected file with a running counter, no database needed
- **Batch window override** — forces watcher to start immediately at any hour, no waiting until 6AM
- **`Ctrl+C` shutdown** — gracefully stops both threads and prints final batch/stream count

---

###  How to test

**Terminal 1** — start watcher
```bash
python test_watcher.py
```

**Terminal 2** — drop files while watcher is running
```bash
cd scripts
python generate_batch_data.py --date 2026-03-17
python generate_stream_data.py --date 2026-03-17 --hour 9
python generate_stream_data.py --date 2026-03-17 --hour 14
```

---

###  Future Changes
- [ ] `FileProcessor` — real processing logic (validate, load to DB)
- [ ] `file_tracking` table — replace in-memory sets so restarts don't reprocess files
- [ ] `Alerter` — send email when batch is missing past 2PM
- [ ] `_get_fallback_batch_dir` — fall back to yesterday's batch if today's never arrives