### PR TITLE
fix: decouple logging from watcher — use pipeline.logging.logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,10 @@
 
 # ── DATA DIRECTORIES ──────────────────────
 data/
- 
+
+# ── LOGS ──────────────────────────────────
+logs/
+
 # ── PYTHON CACHE ──────────────────────────
 __pycache__/
 
@@ -18,8 +21,6 @@ v
 # Python creates these automatically when running code
 *.pyc
 *.pyo
- 
+
 # ── IDE FILES ─────────────────────────────
 .vscode/
-
- 

--- a/pipeline/watcher.py
+++ b/pipeline/watcher.py
@@ -6,31 +6,35 @@ Directory polling for batch and stream files.
 Two pollers run in separate threads:
     BatchPoller  — watches from 6AM, processes 13 batch files once per day,
                    then sleeps until 6AM tomorrow
-    StreamPoller — scans every 30 seconds continuously throughout the day
+    StreamPoller — scans continuously throughout the day for stream files
+                   that arrive at irregular intervals
 
 FUTURE CHANGES NEEDED:
     1. BatchPoller.processor.process() — currently calls TestProcessor (prints only)
        Later: replace with real FileProcessor that validates + loads to DB
     2. processed_today set — currently in-memory only, lost on restart
-       Later: replace with file_tracking table check
+       Later: replace with audit_trail.is_file_processed(filepath) check
     3. processed set — same as above
-       Later: replace with file_tracking table check
+       Later: replace with audit_trail.is_file_processed(filepath) check
     4. Alerter — currently missing, batch failure only logs a warning
        Later: wire in AlertConfig from settings to send email on batch missing
     5. _get_fallback_batch_dir — not implemented yet (IF NEEDED)
        Later: implement fallback to yesterday's batch when today's never arrives
-
-CHECK:
-   LOGGING
 """
 
 import os
 import time
-import logging
 import threading
 from datetime import date, datetime, timedelta
 
-logger = logging.getLogger(__name__)
+from pipeline.logging.logger import (
+    get_logger_name,
+    log_stage_start,
+    log_stage_complete,
+    log_alert_fired,
+)
+
+logger = get_logger_name(__name__)
 
 # ── Expected files ────────────────────────────────────────────
 
@@ -58,7 +62,7 @@ STREAM_FILES = [
 
 # Batch window: only watch between these hours
 BATCH_WINDOW_START = 6   # 6AM  — before this, batch never arrives
-BATCH_WINDOW_END   = 14  # 2PM  — after all 13 done, sleep until next 6AM, but if past 2PM and still missing, keep watching + log warning
+BATCH_WINDOW_END   = 14  # 2PM  — past this with files missing → log CRITICAL alert
 
 
 # ── File stability check ──────────────────────────────────────
@@ -67,7 +71,7 @@ def is_file_stable(filepath: str, wait_sec: int = 1) -> bool:
     """
     Check if a file is done being written.
     Compare size before and after wait_sec seconds.
-    If size is the same the file is safe to read.
+    If size is unchanged the file is safe to read.
 
     wait_sec: 1 for local files, 2-3 for network drives.
     """
@@ -90,7 +94,7 @@ class BatchPoller:
     - Before 6AM: sleep until 6AM — batch never arrives this early
     - 6AM onward: scan every poll_interval seconds until all 13 files found
     - All 13 done: sleep until 6AM tomorrow — no point scanning again today
-    - If batch still missing after 2PM: keep watching + log warning
+    - If batch still missing after 2PM: log CRITICAL alert once, keep watching
     - Midnight: reset for the new day
     """
 
@@ -110,7 +114,7 @@ class BatchPoller:
         self._thread = threading.Thread(
             target=self._run,
             name="BatchPoller",
-            daemon=True 
+            daemon=True
         )
         self._thread.start()
         logger.info("BatchPoller started")
@@ -124,12 +128,11 @@ class BatchPoller:
 
         # CURRENT: in-memory set — lost every time pipeline restarts
         # FUTURE:  remove this set entirely
-        #          replace every check (if filepath in processed_today)
-        #          with: file_tracker.get_status(filepath) == "success"
-        #          where file_tracker is a FileTracker instance from pipeline/file_tracker.py
+        #          replace every (if filepath in processed_today) check
+        #          with: audit_trail.is_file_processed(filepath)
         processed_today = set()
         current_day     = None
-        alert_sent      = False   # prevents sending duplicate alerts same day
+        alert_sent      = False   # prevents duplicate alerts on the same day
 
         while self.running:
             today = date.today().isoformat()
@@ -137,7 +140,7 @@ class BatchPoller:
 
             # ── Midnight reset ─────────────────────────────────
             if today != current_day:
-                logger.info(f"BatchPoller: new day {today}")
+                logger.info("BatchPoller: new day", date=today)
                 processed_today = set()   # FUTURE: no set to clear — file_tracking handles this
                 current_day     = today
                 alert_sent      = False
@@ -150,8 +153,9 @@ class BatchPoller:
                             )
                 sleep_sec = (wake_at - now).total_seconds()
                 logger.info(
-                    f"BatchPoller: before batch window. "
-                    f"Sleeping {sleep_sec/60:.0f} min until 6AM."
+                    "BatchPoller: before batch window, sleeping",
+                    sleep_min=round(sleep_sec / 60),
+                    wake_at=f"{BATCH_WINDOW_START:02d}:00"
                 )
                 time.sleep(sleep_sec)
                 continue
@@ -160,7 +164,7 @@ class BatchPoller:
             batch_dir = os.path.join(self.batch_base_dir, today)
 
             if not os.path.exists(batch_dir):
-                logger.debug(f"BatchPoller: waiting for {batch_dir}")
+                logger.debug("BatchPoller: waiting for batch dir", batch_dir=batch_dir)
                 time.sleep(self.poll_interval)
                 continue
 
@@ -169,10 +173,7 @@ class BatchPoller:
                 filepath = os.path.join(batch_dir, filename)
 
                 # CURRENT: check in-memory set
-                # FUTURE:  status = file_tracker.get_status(filepath)
-                #          if status == "success": continue
-                #          if status == "in_progress": pass  ← reprocess crashed file
-                #          if status is None: pass           ← new file, process it
+                # FUTURE:  if audit_trail.is_file_processed(filepath): continue
                 if filepath in processed_today:
                     continue
 
@@ -180,10 +181,14 @@ class BatchPoller:
                     continue
 
                 if not is_file_stable(filepath):
-                    logger.debug(f"BatchPoller: file still writing: {filepath}")
+                    logger.debug(
+                        "BatchPoller: file still writing",
+                        file=filepath,
+                    )
                     continue
 
-                logger.info(f"BatchPoller: found → {filepath}")
+                # File is ready — log stage start then hand to processor
+                log_stage_start(logger, stage_name="file_detection", file=filepath, poller="batch")
 
                 # CURRENT: calls TestProcessor which only prints
                 # FUTURE:  calls real FileProcessor which:
@@ -196,7 +201,7 @@ class BatchPoller:
                 self.processor.process(filepath, file_type="batch")
 
                 # CURRENT: add to in-memory set
-                # FUTURE:  remove this line — file_tracking table handles dedup
+                # FUTURE:  remove — audit_trail.mark_file_success() handles dedup
                 processed_today.add(filepath)
 
             # ── Check if ALL 13 files are done ─────────────────
@@ -204,7 +209,7 @@ class BatchPoller:
                 os.path.join(batch_dir, f) in processed_today
                 for f in BATCH_FILES
                 # FUTURE: replace with:
-                # file_tracker.get_status(os.path.join(batch_dir, f)) == "success"
+                # audit_trail.is_file_processed(os.path.join(batch_dir, f))
             )
 
             if all_done:
@@ -213,9 +218,16 @@ class BatchPoller:
                     datetime.min.time().replace(hour=BATCH_WINDOW_START)
                 )
                 sleep_sec = (tomorrow_6am - now).total_seconds()
-                logger.info(
-                    f"BatchPoller: all {len(BATCH_FILES)} files processed. "
-                    f"Sleeping {sleep_sec/3600:.1f}h until 6AM tomorrow."
+
+                # All 13 done — log stage complete then sleep until tomorrow
+                log_stage_complete(
+                    logger,
+                    stage_name = "file_detection",
+                    records    = len(BATCH_FILES),
+                    latency_ms = 0.0,
+                    poller     = "batch",
+                    sleep_hours= round(sleep_sec / 3600, 1),
+                    wake_at    = f"{BATCH_WINDOW_START:02d}:00 tomorrow"
                 )
                 time.sleep(sleep_sec)
 
@@ -223,17 +235,23 @@ class BatchPoller:
                 missing = [
                     f for f in BATCH_FILES
                     if os.path.join(batch_dir, f) not in processed_today
-                    # FUTURE: replace condition with file_tracking check
+                    # FUTURE: replace condition with audit_trail check
                 ]
 
                 # ── Past 2PM and still missing — alert once ────
                 if now.hour >= BATCH_WINDOW_END and not alert_sent:
-                    logger.critical(
-                        f"BatchPoller: CRITICAL — past {BATCH_WINDOW_END}:00, "
-                        f"batch still incomplete. Missing: {missing}"
+                    log_alert_fired(
+                        logger,
+                        alert_type    = "BATCH_FILES_MISSING",
+                        severity      = "CRITICAL",
+                        message       = f"Past {BATCH_WINDOW_END:02d}:00 and batch still incomplete",
+                        stage         = "file_detection",
+                        date          = today,
+                        missing       = missing,
+                        missing_count = len(missing),
                     )
 
-                    # FUTURE: send real alert
+                    # FUTURE: send real email alert
                     # self.alerter.send_async(
                     #     subject="CRITICAL: Batch files missing",
                     #     body=f"Date: {today}\nMissing: {missing}"
@@ -250,8 +268,10 @@ class BatchPoller:
 
                 else:
                     logger.debug(
-                        f"BatchPoller: {len(processed_today)}/{len(BATCH_FILES)} done. "
-                        f"Still waiting for: {missing}"
+                        "BatchPoller: batch incomplete, still waiting",
+                        processed=len(processed_today),
+                        total=len(BATCH_FILES),
+                        missing=missing,
                     )
 
                 time.sleep(self.poll_interval)
@@ -269,7 +289,7 @@ class BatchPoller:
     #             for f in BATCH_FILES
     #         )
     #         if past_done:
-    #             logger.warning(f"BatchPoller: fallback found at {past_dir}")
+    #             logger.warning("BatchPoller: fallback batch found", fallback_dir=past_dir)
     #             return past_dir
     #     return None
 
@@ -279,9 +299,13 @@ class BatchPoller:
 class StreamPoller:
     """
     Scans all HH/ subfolders under today's stream directory.
-    Runs every 30 seconds continuously.
+    Runs continuously, scanning every poll_interval seconds.
     Calls processor.process() for each new file found.
     Each file is reported exactly once per session.
+
+    Files arrive at irregular intervals throughout the day — not on a fixed schedule.
+    Hour folders are scanned oldest → newest for correct ordering on recovery
+    after an unexpected restart.
 
     Within-session dedup:  handled by processed set (current)
     Cross-restart dedup:   handled by file_tracking table (future)
@@ -314,7 +338,7 @@ class StreamPoller:
         # CURRENT: in-memory set — works within one session only
         # FUTURE:  remove this set entirely
         #          replace (if filepath in processed) check
-        #          with: file_tracker.get_status(filepath) == "success"
+        #          with: audit_trail.is_file_processed(filepath)
         processed = set()
 
         while self.running:
@@ -322,11 +346,12 @@ class StreamPoller:
             stream_dir = os.path.join(self.stream_base_dir, today)
 
             if not os.path.exists(stream_dir):
-                logger.debug(f"StreamPoller: no stream dir yet for {today}")
+                logger.debug("StreamPoller: no stream dir yet", date=today)
                 time.sleep(self.poll_interval)
                 continue
 
             # Scan all HH/ subfolders sorted oldest → newest
+            # Ensures correct processing order on recovery after unexpected restart
             hour_folders = sorted([
                 f for f in os.listdir(stream_dir)
                 if os.path.isdir(os.path.join(stream_dir, f))
@@ -342,18 +367,26 @@ class StreamPoller:
                         continue
 
                     # CURRENT: check in-memory set
-                    # FUTURE:  status = file_tracker.get_status(filepath)
-                    #          if status == "success":     continue
-                    #          if status == "in_progress": pass  ← crashed, reprocess
-                    #          if status is None:          pass  ← new file
+                    # FUTURE:  if audit_trail.is_file_processed(filepath): continue
                     if filepath in processed:
                         continue
 
                     if not is_file_stable(filepath):
-                        logger.debug(f"StreamPoller: file still writing: {filepath}")
+                        logger.debug(
+                            "StreamPoller: file still writing",
+                            file=filepath,
+                            hour=hour_folder,
+                        )
                         continue
 
-                    logger.info(f"StreamPoller: found → {filepath}")
+                    # File is ready — log stage start then hand to processor
+                    log_stage_start(
+                        logger,
+                        stage_name = "file_detection",
+                        file       = filepath,
+                        poller     = "stream",
+                        hour       = hour_folder,
+                    )
 
                     # CURRENT: calls TestProcessor which only prints
                     # FUTURE:  calls real FileProcessor which:
@@ -370,7 +403,7 @@ class StreamPoller:
                     self.processor.process(filepath, file_type="stream")
 
                     # CURRENT: add to in-memory set
-                    # FUTURE:  remove — file_tracking handles this permanently
+                    # FUTURE:  remove — audit_trail.mark_file_success() handles this
                     processed.add(filepath)
 
             time.sleep(self.poll_interval)

--- a/test_watcher.py
+++ b/test_watcher.py
@@ -1,21 +1,27 @@
 """
-tests/test_watcher.py
-─────────────────────
+test_watcher.py
+───────────────
 Live watcher test — runs until Ctrl+C.
 
 How to use:
-    Terminal 1: python tests/test_watcher.py
-    Terminal 2: python scripts/generate_stream_data.py --date 2026-03-17 --hour 10
+    Terminal 1 (project root): python test_watcher.py
+    Terminal 2 (scripts/):      python generate_batch_data.py --date 2026-03-18
+                                python generate_stream_data.py --date 2026-03-18 --hour 9
+
+Logging:
+    All structured JSON logs are written by watcher.py itself.
+    This file only calls configure_logging() once to set up the log file.
+    Logs are written to: logs/pipeline.log
 """
 
 import os
 import sys
 import signal
-import logging
 import pipeline.watcher as watcher_module
 
 from datetime import datetime
 from pipeline.watcher import BatchPoller, StreamPoller
+from pipeline.logging.logger import configure_logging
 
 # ── Constants ─────────────────────────────────────────────────
 BATCH_DIR  = "scripts/data/input/batch"
@@ -26,22 +32,23 @@ STREAM_POLL_INTERVAL = 5    # seconds — 30 in production
 
 # ── Override batch window so test works at any hour of day ────
 watcher_module.BATCH_WINDOW_START = datetime.now().hour
-watcher_module.BATCH_WINDOW_END   = datetime.now().hour + 8
+watcher_module.BATCH_WINDOW_END = min(datetime.now().hour + 8, 23)
 
-# ── Logging ───────────────────────────────────────────────────
-logging.basicConfig(
-    level  = logging.INFO,
-    format = "%(asctime)s | %(threadName)-12s | %(message)s",
-    datefmt= "%H:%M:%S"
-)
+# ── Logging setup ─────────────────────────────────────────────
+# Called once here — watcher.py handles all actual log calls
+configure_logging(log_dir="logs", level="INFO")
 
 
 # ── Processor ─────────────────────────────────────────────────
 class TestProcessor:
     """
     Receives detected files from both pollers.
-    Prints each file and keeps a running count.
+    Prints each file to terminal with a running counter.
     In production this would be replaced by the real FileProcessor.
+
+    Note: No logging here — watcher.py already logs every file detection
+    via log_stage_start(). This class only prints to terminal for
+    live visibility during testing.
     """
 
     def __init__(self):
@@ -49,8 +56,8 @@ class TestProcessor:
         self.stream_count = 0
 
     def process(self, filepath: str, file_type: str) -> None:
-        filename    = os.path.basename(filepath)
-        parent_dir  = os.path.basename(os.path.dirname(filepath))
+        filename   = os.path.basename(filepath)
+        parent_dir = os.path.basename(os.path.dirname(filepath))
 
         if file_type == "batch":
             self.batch_count += 1
@@ -75,6 +82,7 @@ def build_shutdown_handler(batch_poller, stream_poller, processor):
         stream_poller.stop()
         print(f"  Batch files detected:  {processor.batch_count}")
         print(f"  Stream files detected: {processor.stream_count}")
+        print(f"  Logs written to:       logs/pipeline.log")
         print("=" * 55)
         sys.exit(0)
 
@@ -91,10 +99,12 @@ def print_banner():
     print(f"  Batch window: {watcher_module.BATCH_WINDOW_START}:00 — {watcher_module.BATCH_WINDOW_END}:00")
     print(f"  Batch poll:   every {BATCH_POLL_INTERVAL}s  (production: 60s)")
     print(f"  Stream poll:  every {STREAM_POLL_INTERVAL}s  (production: 30s)")
+    print(f"  Logs:         logs/pipeline.log")
     print()
-    print("  Send files from Terminal 2:")
+    print("  Drop files from Terminal 2:")
     print("  cd scripts")
-    print("  python generate_stream_data.py --date 2026-03-17 --hour 10")
+    print("  python generate_batch_data.py --date 2026-03-18")
+    print("  python generate_stream_data.py --date 2026-03-18 --hour 9")
     print()
     print("  Press Ctrl+C to stop")
     print("=" * 55)
@@ -117,7 +127,7 @@ def main():
         poll_interval   = STREAM_POLL_INTERVAL
     )
 
-    # Register shutdown 
+    # Register Ctrl+C shutdown handler
     shutdown = build_shutdown_handler(batch_poller, stream_poller, processor)
     signal.signal(signal.SIGINT, shutdown)
 


### PR DESCRIPTION
### Logging
All logging is handled via `pipeline.logging.logger` — `watcher.py` 
has no direct dependency on Python's `logging` module.

| Call | Purpose |
|------|---------|
| `get_logger_name()` | Get named logger for this module |
| `log_stage_start()` | Every file detected |
| `log_stage_complete()` | All 13 batch files done |
| `log_alert_fired()` | Batch missing past 2PM |
| `logger.info/debug()` | Simple lifecycle messages (started, stopped, new day, waiting) |
| `configure_logging()` | Called once in `test_watcher.py` as entry point |

Logs are written to `logs/pipeline.log` as structured JSON.